### PR TITLE
Support for multifiles & pytlinting & more testing

### DIFF
--- a/.pylint
+++ b/.pylint
@@ -1,0 +1,363 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=data,docs,test_data
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=getslice-method,unicode-builtin,useless-suppression,old-raise-syntax,cmp-builtin,import-star-module-level,unpacking-in-except,standarderror-builtin,cmp-method,suppressed-message,parameter-unpacking,round-builtin,file-builtin,old-division,raw_input-builtin,print-statement,range-builtin-not-iterating,oct-method,reload-builtin,execfile-builtin,zip-builtin-not-iterating,long-builtin,using-cmp-argument,next-method-called,apply-builtin,backtick,no-absolute-import,dict-iter-method,old-octal-literal,coerce-method,long-suffix,raising-string,filter-builtin-not-iterating,delslice-method,indexing-exception,hex-method,setslice-method,dict-view-method,buffer-builtin,coerce-builtin,unichr-builtin,input-builtin,old-ne-operator,xrange-builtin,map-builtin-not-iterating,reduce-builtin,basestring-builtin,nonzero-method,metaclass-assignment,intern-builtin,missing-docstring,expression-not-assigned,bad-continuation,too-many-arguments,bad-builtin
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=yes
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 
 test:
 	py.test
+
+lint:
+	pylint --rcfile .pylint textkit/*/**.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML>=3.11
 six>=1.10.0
 wheel>=0.26.0
 unittest2>=1.1.0
+pylint>=1.5.5

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -3,44 +3,42 @@ from click.testing import CliRunner
 from textkit.filter.filter_punc import filterpunc
 from textkit.filter.filter_words import filterwords
 from textkit.filter.filter_lengths import filterlengths
-
+from tests.utils import create_single_output, create_multifile_output, compare_results
 
 def test_filterlengths():
     runner = CliRunner()
     with runner.isolated_filesystem():
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello\nWorld\n!\nI\n.\nnot\nwin\n')
-
+        sentence = 'Hello\nWorld\n!\nI\n.\nnot\nwin\n'
+        
+        create_single_output(filename, sentence)
+        
+        # default length 3
         result = runner.invoke(filterlengths, [filename])
-
+        tokens = result.output.split('\n')
+        expected_tokens = ['Hello', 'World', 'not', 'win'] 
         assert result.exit_code == 0
-        assert '!' not in result.output
-        assert '.' not in result.output
-        assert 'not' in result.output
-        assert 'World' in result.output
+        compare_results(tokens, expected_tokens)
 
+        # minumum length 4
         result = runner.invoke(filterlengths, ['-m', '4', filename])
-
+        tokens = result.output.split('\n')
+        expected_tokens = ['Hello', 'World']
         assert result.exit_code == 0
-        assert '!' not in result.output
-        assert '.' not in result.output
-        assert 'not' not in result.output
-        assert 'World' in result.output
+        compare_results(tokens, expected_tokens)
 
 
 def test_filterpunc():
     runner = CliRunner()
     with runner.isolated_filesystem():
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello\nWorld\n!\nI\n.\nnot')
-
+        sentence = 'Hello\nWorld\n!\nI\n.\nnot'
+        expected_tokens = ['Hello', 'World', 'I', 'not']
+        create_single_output(filename, sentence)
         result = runner.invoke(filterpunc, [filename])
-
+        tokens = result.output.split('\n')
         assert result.exit_code == 0
-        assert '!' not in result.output
-        assert '.' not in result.output
+        compare_results(tokens, expected_tokens)
 
 
 def test_filterwords():
@@ -48,14 +46,13 @@ def test_filterwords():
     with runner.isolated_filesystem():
 
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello\nWorld\n!\nI\nam\nnot\na\ncrook\n.')
-
+        sentence = 'Hello\nWorld\n!\nI\nam\nnot\na\ncrook\n.'
+        expected_tokens = ['Hello','World','!', 'crook','.']
+        create_single_output(filename, sentence)
         result = runner.invoke(filterwords, ['--language', 'english', filename])
-
+        tokens = result.output.split('\n')
         assert result.exit_code == 0
-        assert 'I' not in result.output
-        assert 'am' not in result.output
+        compare_results(tokens, expected_tokens)
 
 
 def test_filterwords_custom():
@@ -63,16 +60,15 @@ def test_filterwords_custom():
     with runner.isolated_filesystem():
 
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello\nWorld\n!\nI\nam\nnot\na\ncrook\n.')
+        sentence = 'Hello\nWorld\n!\nI\nam\nnot\na\ncrook\n.'
+        expected_tokens = ['World','!','crook','.']
+        custom_stopword_filename = 'custom.txt'
+        custom_stopwords = 'hello\n'
 
-        filename = 'custom.txt'
-        with open(filename, 'w') as f:
-            f.write('hello\n')
+        create_single_output(filename, sentence)
+        create_single_output(custom_stopword_filename, custom_stopwords)
 
         result = runner.invoke(filterwords, ['--custom', 'custom.txt', filename])
-
+        tokens = result.output.split('\n')
         assert result.exit_code == 0
-        assert 'I' not in result.output
-        assert 'am' not in result.output
-        assert 'Hello' not in result.output
+        compare_results(tokens, expected_tokens)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,21 @@
+import click
+from click.testing import CliRunner
+from textkit.stats.count_tokens import count_tokens
+from textkit.stats.top_bigrams import top_bigrams
+from tests.utils import create_single_output, create_multifile_output, compare_results
+
+def test_count_tokens():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        filename = 'in.txt'
+        sentence = 'Hello\nworld\n!\nI\nlove\nthis\nworld\nand\nlove\nyou'
+        expected_tokens = ['love,2', 'world,2', 'and,1', 'I,1', 'you,1', 'this,1', 'Hello,1', '!,1', '']
+        expected_tokens.sort()
+        create_single_output(filename, sentence)
+        result = runner.invoke(count_tokens, [filename])
+        tokens = result.output.split('\n')
+        tokens.sort()
+        assert result.exit_code == 0
+        compare_results(tokens, expected_tokens)
+
+# Need to write test for top bigrams!

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -1,31 +1,82 @@
 from click.testing import CliRunner
 from textkit.tokenize.words import text2words
 from textkit.tokenize.bigrams import words2bigrams
-
+from textkit.tokenize.punc import text2punc
+from textkit.tokenize.sentences import text2sentences
+from tests.utils import create_single_output, create_multifile_output, compare_results
 
 def test_text2words():
     runner = CliRunner()
     with runner.isolated_filesystem():
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello World!\nI.\nnot sure where to go')
-
+        sentence = 'Hello World!\nI.\nnot sure where to go'
+        expected_tokens = ['Hello', 'World', '!', 'I.', 'not', 'sure', 'where', 'to', 'go'] 
+        create_single_output(filename, sentence)
         result = runner.invoke(text2words, [filename])
         tokens = result.output.split('\n')
-
         assert result.exit_code == 0
-        assert tokens[0] == 'Hello'
+        compare_results(tokens, expected_tokens)
 
+def test_text2words_multifile():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+
+        filenames = ['in.txt', 'in2.txt']
+        sentences = ('Hello World!\nI.\nnot sure where to go',
+            'Goodbye World!\n I.\n know everything about you')
+        expected_tokens = ['Hello', 'World', '!', 'I.', 'not', 'sure', 'where', 'to', 'go', 
+            'Goodbye', 'World', '!', 'I.', 'know', 'everything', 'about', 'you']
+        create_multifile_output(filenames, sentences)
+        result = runner.invoke(text2words, filenames)
+        tokens = result.output.split('\n')
+        assert result.exit_code == 0
+        compare_results(tokens, expected_tokens)
 
 def test_words2bigrams():
     runner = CliRunner()
     with runner.isolated_filesystem():
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello\nWorld\n!\nI\nlove\ngo\n.')
-
+        sentence = 'Hello\nWorld\n!\nI\nlove\ngo\n.'
+        expected_tokens = ['Hello World', 'World !', '! I', 'I love', 'love go', 'go .']
+        create_single_output(filename, sentence)
         result = runner.invoke(words2bigrams, [filename])
         tokens = result.output.split('\n')
         assert result.exit_code == 0
-        assert tokens[0] == 'Hello World'
-        assert tokens[1] == 'World !'
+        compare_results(tokens, expected_tokens)
+
+def test_sentences():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        filename = 'in.txt'
+        sentence = 'Hello World! I love go.'
+        expected_tokens = ['Hello World!', 'I love go.']
+        create_single_output(filename, sentence)
+        result = runner.invoke(text2sentences, [filename])
+        tokens = result.output.split('\n')
+        assert result.exit_code == 0
+        compare_results(tokens, expected_tokens)
+
+def test_punc():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        filename = 'in.txt'
+        sentence = 'Hello\nWorld\n!\nI\nlove,\ngo\n.'
+        expected_tokens = ['!', ',', '.']
+        create_single_output(filename, sentence)
+        result = runner.invoke(text2punc, [filename])
+        tokens = result.output.split('\n')
+        assert result.exit_code == 0
+        compare_results(tokens, expected_tokens)
+
+def test_punc_multifile():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        filenames = ['in.txt', 'in2.txt']
+        sentences = ['Hello\nWorld\n!\nI\nlove,\ngo\n.',
+            'Goodbye World!\n I...\n know everything\'s about you?']
+        expected_tokens = ['!', ',', '.', '!', '...', "'", '?']
+        create_multifile_output(filenames, sentences)
+        result = runner.invoke(text2punc, filenames)
+        tokens = result.output.split('\n')
+        assert result.exit_code == 0
+        compare_results(tokens, expected_tokens)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -2,32 +2,60 @@
 from click.testing import CliRunner
 from textkit.transform.lowercase import lowercase
 from textkit.transform.newlines import nonewlines
-
+from textkit.transform.uppercase import uppercase
+from tests.utils import create_single_output, create_multifile_output, compare_results
 
 def test_lowercase():
     runner = CliRunner()
     with runner.isolated_filesystem():
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello\nWorld\n!\nI\n.\nnoooo\n')
+        sentence = 'Hello\nWorld\n!\nI\n.\nnoooo\n'
+        expected_tokens = ['hello', 'world', '!', 'i', '.', 'noooo']
+        create_single_output(filename, sentence)
 
         result = runner.invoke(lowercase, [filename])
-
+        tokens = result.output.split('\n')
         assert result.exit_code == 0
-        assert result.output.split('\n')[0] == 'hello'
-        assert result.output.split('\n')[1] == 'world'
+        compare_results(tokens, expected_tokens)
 
+def test_uppercase():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        filename = 'in.txt'
+        sentence = 'Hello\nWorld\n!\nI\n.\nnoooo\n'
+        expected_tokens = ['HELLO', 'WORLD', '!', 'I', '.', 'NOOOO']
+        create_single_output(filename, sentence)
+
+        result = runner.invoke(uppercase, [filename])
+        tokens = result.output.split('\n')
+        assert result.exit_code == 0
+        compare_results(tokens, expected_tokens)
 
 def test_nonewlines():
     runner = CliRunner()
     with runner.isolated_filesystem():
         filename = 'in.txt'
-        with open(filename, 'w') as f:
-            f.write('Hello\nWorld\n!\nI\nam\nin.\n')
-
+        sentence = 'Hello\nWorld\n!\nI\nam\nin.\n'
+        expected_tokens = ['Hello World ! I am in.']
+        
+        create_single_output(filename, sentence)
         result = runner.invoke(nonewlines, [filename])
-
+        tokens = result.output.split('\n')
         assert result.exit_code == 0
         assert len(result.output.split('\n')) == 2
-        assert result.output.split('\n')[1] == ''
-        assert result.output.split('\n')[0] == 'Hello World ! I am in.'
+        compare_results(tokens, expected_tokens)
+
+
+def test_nonewlines_multifile():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        filenames = ['in.txt', 'in2.txt']
+        sentences = ['Hello\nWorld\n!\nI\nam\nin.', 
+            'What are you\na creature\nof mystery']
+        expected_tokens = ['Hello World ! I am in. What are you a creature of mystery']
+        create_multifile_output(filenames, sentences)
+        result = runner.invoke(nonewlines, filenames)
+        tokens = result.output.split('\n')
+        assert result.exit_code == 0
+        assert len(result.output.split('\n')) == 2
+        compare_results(tokens, expected_tokens)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ def test_read_tokens():
     f = open('test_data/word_tokens.txt', 'r')
 
     tokens = read_tokens(f)
-    print(tokens)
     assert len(tokens) == 6
 
     f.close()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,18 @@
+def create_single_output(filename, content):
+	"""
+	Outputs test content into a filename
+	"""
+	with open(filename, 'w') as f:
+		f.write(content)
+
+def create_multifile_output(filenames, contents):
+	"""
+	Outputs several text contents into several files
+	"""
+	for idx, filename in enumerate(filenames):
+		with open(filename, 'w') as f:
+			f.write(contents[idx])
+
+def compare_results(tokens, expected_tokens):
+	for tdx, expected_token in enumerate(expected_tokens):
+		assert tokens[tdx] == expected_tokens[tdx]

--- a/textkit/cli.py
+++ b/textkit/cli.py
@@ -19,8 +19,6 @@ from textkit.package.tokens_to_text import tokens2text
 from textkit.stats.count_tokens import count_tokens
 from textkit.stats.top_bigrams import top_bigrams
 
-
-
 @click.group()
 def cli():
     '''Text analysis from the command line.

--- a/textkit/filter/filter_lengths.py
+++ b/textkit/filter/filter_lengths.py
@@ -1,14 +1,11 @@
 import click
-from string import punctuation
 from textkit.utils import output, read_tokens
-
 
 @click.command()
 @click.argument('tokens', type=click.File('r'))
-@click.option('-m', '--min', default=3,
+@click.option('-m', '--minimum', default=3,
               help='Minimum length of token to not filter.', show_default=True)
-def filterlengths(min, tokens):
+def filterlengths(minimum, tokens):
     '''Remove tokens that are shorter then the minimum length provided.'''
     content = read_tokens(tokens)
-    [output(token) for token in content
-        if len(token) >= min]
+    [output(token) for token in content if len(token) >= minimum]

--- a/textkit/filter/filter_punc.py
+++ b/textkit/filter/filter_punc.py
@@ -1,7 +1,6 @@
-import click
 from string import punctuation
+import click
 from textkit.utils import output, read_tokens
-
 
 @click.command()
 # @click.option('--out', type=click.File('w'), default='-',
@@ -12,5 +11,4 @@ from textkit.utils import output, read_tokens
 def filterpunc(tokens):
     '''Remove tokens that are only punctuation from a list of tokens.'''
     content = read_tokens(tokens)
-    [output(token) for token in content
-        if token not in punctuation]
+    [output(token) for token in content if token not in punctuation]

--- a/textkit/filter/filter_words.py
+++ b/textkit/filter/filter_words.py
@@ -1,15 +1,14 @@
-import click
 import os
-from string import punctuation
+import click
 from textkit.utils import output, read_tokens
 
 
-def get_stopwords(id):
+def get_stopwords(stopword_file):
     cur_dir = os.path.dirname(os.path.realpath(__file__))
-    path = cur_dir + "/../../data/stopwords/" + id + ".txt"
+    path = cur_dir + "/../../data/stopwords/" + stopword_file + ".txt"
     stopwords = []
-    with open(path) as f:
-        stopwords = read_tokens(f)
+    with open(path) as filename:
+        stopwords = read_tokens(filename)
     return stopwords
 
 
@@ -17,13 +16,14 @@ def get_stopwords(id):
 @click.option('-l', '--language', type=click.Choice(['english', 'german']),
               default='english')
 @click.option('--custom', type=click.File('r'),
-              help='Optional token file of additional tokens to remove along with selected stop words.')
+              help='Optional token file of additional tokens to remove ' +
+              'along with selected stop words.')
 @click.argument('tokens', type=click.File('r'))
 def filterwords(language, custom, tokens):
     '''Remove stop words from tokens, returning tokens without stop words.'''
     content = read_tokens(tokens)
     stopwords = get_stopwords(language)
-    if(custom):
+    if custom:
         stopwords = stopwords + read_tokens(custom)
 
     [output(token) for token in content

--- a/textkit/package/texts_to_json.py
+++ b/textkit/package/texts_to_json.py
@@ -1,26 +1,29 @@
-import click
 import json
-from textkit.utils import output, read_tokens
 from collections import OrderedDict
-
+import click
+from textkit.utils import output, read_tokens
 
 def read_names(names_path):
     names = []
-    if(names_path):
+    if names_path:
         names_doc = open(names_path, 'r')
         names = read_tokens(names_doc)
     return names
 
 
 @click.command()
-@click.argument('text_docs', type=click.Path(), nargs=-1)
+@click.argument('text_docs', type=click.Path(exists=True), nargs=-1)
 @click.option('--ids', type=click.Path(),
-              help="File with one id per text document, each separated by a new line. Ids file is used to set the id attribute in the output JSON."
-              )
+              help="File with one id per text document, each separated by a " +
+              "new line. Ids file is used to set the id attribute in the " +
+              "output JSON.")
 @click.option('--names', type=click.Path(),
-              help="File with one name per text document, each separated by a new line. Names file is used to set the name attribute in the output JSON."
-              )
-@click.option('--field', default='text', help="Attribute name where text will be stored in the document object.", show_default=True)
+              help="File with one name per text document, each separated " +
+              "by a new line. Names file is used to set the name attribute " +
+              "in the output JSON.")
+@click.option('--field', default='text', help="Attribute name where text " +
+              "will be stored in the document object.", show_default=True)
+
 def texts2json(ids, names, field, text_docs):
     '''Convert a set of text documents into a
     JSON array of document objects.'''
@@ -33,17 +36,18 @@ def texts2json(ids, names, field, text_docs):
     for idx, path in enumerate(text_docs):
         tokens_doc = open(path, 'r')
         content = ""
-        with click.open_file(path) as f:
+        with click.open_file(path):
             content = tokens_doc.read()
+
         # ordered so that these attributes stay at the top
         doc = OrderedDict()
 
-        if(idx < len(ids) - 1):
+        if idx < len(ids) - 1:
             doc['id'] = ids[idx]
         else:
             doc['id'] = path
 
-        if(idx < len(names) - 1):
+        if idx < len(names) - 1:
             doc['name'] = names[idx]
         else:
             doc['name'] = path

--- a/textkit/package/tokens_to_json.py
+++ b/textkit/package/tokens_to_json.py
@@ -1,30 +1,36 @@
-import click
 import sys
 import json
+from collections import OrderedDict
+import click
 from textkit.utils import output, read_tokens
 from textkit.coerce import coerce_types
-from collections import OrderedDict
-
 
 def read_names(names_path):
     names = []
-    if(names_path):
+    if names_path:
         names_doc = open(names_path, 'r')
         names = read_tokens(names_doc)
     return names
 
-
 @click.command()
-@click.argument('token_docs', type=click.Path(), nargs=-1)
+@click.argument('token_docs', type=click.Path(exists=True), nargs=-1)
 @click.option('--ids', type=click.Path(),
-              help="File with one id per token document, each separated by a new line. Ids file is used to set the id attribute in the output JSON."
-              )
+              help="File with one id per token document, each separated " +
+              "by a new line. Ids file is used to set the id attribute in " +
+              "the output JSON.")
 @click.option('--names', type=click.Path(),
-              help="File with one name per token document, each separated by a new line. Names file is used to set the name attribute in the output JSON."
-              )
-@click.option('--field', default='tokens', help="Attribute name where tokens will be stored in the document object.", show_default=True)
-@click.option('--columns', default=1, help="Indicate how many columns are present in token rows. If more then one, textkit will attempt to produce JSON arrays for each row.", show_default=True)
-@click.option('--sep', default=',', help="Separator character between columns. Only used if columns is greater then 1.", show_default=True)
+              help="File with one name per token document, each separated " +
+              "by a new line. Names file is used to set the name attribute " +
+              "in the output JSON.")
+@click.option('--field', default='tokens', help="Attribute name where tokens "+
+              "will be stored in the document object.", show_default=True)
+@click.option('--columns', default=1, help="Indicate how many columns are " +
+              "present in token rows. If more then one, textkit will attempt " +
+              "to produce JSON arrays for each row.", show_default=True)
+@click.option('--sep', default=',', help="Separator character between " +
+             "columns. Only used if columns is greater then 1.",
+             show_default=True)
+
 def tokens2json(ids, names, field, columns, sep, token_docs):
     '''Convert a set of token documents into a
     JSON array of document objects.'''
@@ -42,7 +48,7 @@ def tokens2json(ids, names, field, columns, sep, token_docs):
         content = read_tokens(tokens_doc)
 
         # Split rows into columns
-        if(columns > 1):
+        if columns > 1:
             content = [c.split(sep) for c in content]
             # attempt to coerce types
             content = coerce_types(content)
@@ -50,12 +56,12 @@ def tokens2json(ids, names, field, columns, sep, token_docs):
         # ordered so that these attributes stay at the top
         doc = OrderedDict()
 
-        if(idx < len(ids) - 1):
+        if idx < len(ids) - 1:
             doc['id'] = ids[idx]
         else:
             doc['id'] = path
 
-        if(idx < len(names) - 1):
+        if idx < len(names) - 1:
             doc['name'] = names[idx]
         else:
             doc['name'] = path

--- a/textkit/stats/top_bigrams.py
+++ b/textkit/stats/top_bigrams.py
@@ -3,13 +3,13 @@ import nltk
 from textkit.utils import read_tokens, output
 
 
-measures = {
+MEASURES = dict({
     'likelihood': nltk.collocations.BigramAssocMeasures.likelihood_ratio,
     'chi_sq': nltk.collocations.BigramAssocMeasures.chi_sq,
     'pmi': nltk.collocations.BigramAssocMeasures.pmi,
     'student_t': nltk.collocations.BigramAssocMeasures.student_t,
     'freq': nltk.collocations.BigramAssocMeasures.raw_freq
-}
+})
 
 
 @click.command('topbigrams')
@@ -17,8 +17,8 @@ measures = {
 @click.option('--sep', default=' ',
               help='Separator between tokens and scores in output.',
               show_default=True)
-@click.option('-m', '--measure', type=click.Choice(list(measures.keys())),
-              default=list(measures.keys())[0],
+@click.option('-m', '--measure', type=click.Choice(list(MEASURES.keys())),
+              default=list(MEASURES.keys())[0],
               help='Specify which measure to use to define interesing-ness.',
               show_default=True)
 @click.option('--freq', default=2,
@@ -29,7 +29,8 @@ measures = {
               show_default=True)
 def top_bigrams(sep, measure, freq, scores, tokens):
     '''Find top most interesting bi-grams in a token document.
-    Uses the --measure argument to determine what measure to use to define 'interesting'.
+    Uses the --measure argument to determine what measure to use to define
+    'interesting'.
     '''
 
     output(sep)
@@ -37,10 +38,10 @@ def top_bigrams(sep, measure, freq, scores, tokens):
     bcf = nltk.collocations.BigramCollocationFinder.from_words(content)
     bcf.apply_freq_filter(freq)
 
-    nltk_measure = measures[measure]
+    nltk_measure = MEASURES[measure]
     bigrams = bcf.score_ngrams(nltk_measure)
 
     out = [b[0] for b in bigrams]
-    if(scores):
+    if scores:
         out = [b[0] + tuple([str(b[1])]) for b in bigrams]
     [output(sep.join(line)) for line in out]

--- a/textkit/tokenize/ngrams.py
+++ b/textkit/tokenize/ngrams.py
@@ -3,19 +3,19 @@ import nltk
 from textkit.utils import output, read_tokens
 
 
-@click.command()
+@click.command('ngrams')
 @click.argument('tokens', type=click.File('r'))
 @click.option('--sep', default=' ',
               help='Separator between words in bigram output.',
               show_default=True)
-@click.option('-n', '--n', default=2,
+@click.option('-n', '--length', default=2,
               help='Length of the n-gram',
               show_default=True)
 
-def words2ngrams(sep, n, tokens):
+def words2ngrams(sep, length, tokens):
     '''Tokenize words into ngrams. ngrams are n-length word tokens.
     Punctuation is considered as a separate token.'''
 
     content = read_tokens(tokens)
-    ngrams = list(nltk.ngrams(content, n))
+    ngrams = list(nltk.ngrams(content, length))
     [output(sep.join(ngram)) for ngram in ngrams]

--- a/textkit/tokenize/ngrams.py
+++ b/textkit/tokenize/ngrams.py
@@ -3,7 +3,7 @@ import nltk
 from textkit.utils import output, read_tokens
 
 
-@click.command('ngrams')
+@click.command('words2ngrams')
 @click.argument('tokens', type=click.File('r'))
 @click.option('--sep', default=' ',
               help='Separator between words in bigram output.',

--- a/textkit/tokenize/punc.py
+++ b/textkit/tokenize/punc.py
@@ -1,19 +1,17 @@
-import click
-import nltk
 import re
 from string import punctuation
+import click
 from textkit.utils import output
 
-
 @click.command()
-@click.argument('text', type=click.File('r'))
+@click.argument('text', type=click.Path(exists=True), nargs=-1)
 def text2punc(text):
     '''Tokenize text into punctuation tokens.
     Words and numbers are removed, leaving only punctuation.'''
 
     # from: http://stackoverflow.com/questions/17485092/how-to-just-keep-punctuation-with-a-string-in-python
 
-    content = text.read()
+    content = '\n'.join([open(f).read() for f in text])
     out = re.sub(r'[^{}]+'.format(punctuation), ' ', content)
     out = out.split()
     [output(p) for p in out]

--- a/textkit/tokenize/sentences.py
+++ b/textkit/tokenize/sentences.py
@@ -1,12 +1,11 @@
-import re
+from nltk.tokenize import sent_tokenize
 import click
 from textkit.utils import output
 
-
 @click.command()
-@click.argument('text', type=click.File('r'))
+@click.argument('text', type=click.Path(exists=True), nargs=-1)
 def text2sentences(text):
     '''Tokenize text into sentence tokens.'''
-    content = text.read()
-    sentences = re.split(r' *[\.\?!][\'"\)\]]* *', content)
+    content = '\n'.join([open(f).read() for f in text])
+    sentences = sent_tokenize(content)
     [output(s.strip()) for s in sentences]

--- a/textkit/tokenize/words.py
+++ b/textkit/tokenize/words.py
@@ -4,11 +4,12 @@ from textkit.utils import output
 
 
 @click.command()
-@click.argument('text', type=click.File('r'))
+@click.argument('text', type=click.Path(exists=True), nargs=-1)
 def text2words(text):
     '''Tokenize text into word tokens.
     Punctuation is considered as a separate token.'''
-
-    content = text.read()
+    content = '\n'.join([open(f).read() for f in text])
     tokens = nltk.word_tokenize(content)
     [output(token) for token in tokens]
+
+

--- a/textkit/transform/newlines.py
+++ b/textkit/transform/newlines.py
@@ -3,9 +3,9 @@ from textkit.utils import output
 
 
 @click.command()
-@click.argument('text', type=click.File('r'))
+@click.argument('text', type=click.Path(exists=True), nargs=-1)
 def nonewlines(text):
     '''Remove newlines from a text file.'''
-    content = text.read()
+    content = '\n'.join([open(f).read() for f in text])
     content = content.replace('\n', ' ').strip()
     output(content)

--- a/textkit/transform/uppercase.py
+++ b/textkit/transform/uppercase.py
@@ -1,7 +1,6 @@
 import click
 from textkit.utils import read_tokens, output
 
-
 @click.command()
 @click.argument('tokens', type=click.File('r'))
 def uppercase(tokens):


### PR DESCRIPTION
- Added support for multiple file inputs. No additional formatting required - only for text, not token inputs.
- Added some missing tests
- Added tests for multiline inputs 
- added pylinting (fixed long strings, const naming, if paren usage mostly.) To run call "make lint"

(I did not actually change count to use Counter for backwards compat.)