### PR TITLE
Include data files in a portable way.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include data/**/*

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     py_modules=['textkit'],
     url='https://github.com/learntextvis/textkit',
     keywords=['text', 'analysis', 'textkit'],
+    include_package_data=True,
     install_requires=[
         'click>=6.2',
         'nltk>=3.1'

--- a/textkit/filter/filter_words.py
+++ b/textkit/filter/filter_words.py
@@ -1,11 +1,13 @@
 import os
 import click
 from textkit.utils import output, read_tokens
+from pkg_resources import resource_filename
 
 
-def get_stopwords(stopword_file):
-    cur_dir = os.path.dirname(os.path.realpath(__file__))
-    path = cur_dir + "/../../data/stopwords/" + stopword_file + ".txt"
+def get_stopwords(stopword_name):
+    path = resource_filename(__name__, '/../../data/stopwords/' +
+                             stopword_name + '.txt')
+    print(path)
     stopwords = []
     with open(path) as filename:
         stopwords = read_tokens(filename)

--- a/textkit/filter/filter_words.py
+++ b/textkit/filter/filter_words.py
@@ -7,7 +7,6 @@ from pkg_resources import resource_filename
 def get_stopwords(stopword_name):
     path = resource_filename(__name__, '/../../data/stopwords/' +
                              stopword_name + '.txt')
-    print(path)
     stopwords = []
     with open(path) as filename:
         stopwords = read_tokens(filename)


### PR DESCRIPTION
According to [this documentation](https://pythonhosted.org/setuptools/setuptools.html#including-data-files) the data files weren't actually getting added to the egg package - and so would not be around for users. 

This PR attempts to fix this and access the included data file's contents in a portable way (cause I guess you can't guarantee the location of the data files and have to rely on `pkg_resources`. 