### PR TITLE
basic stemming feature

### DIFF
--- a/textkit/cli.py
+++ b/textkit/cli.py
@@ -13,6 +13,7 @@ from textkit.filter.filter_words import showstops
 from textkit.transform.lowercase import lowercase
 from textkit.transform.uppercase import uppercase
 from textkit.transform.newlines import nonewlines
+from textkit.transform.stem import stem
 from textkit.package.tokens_to_json import tokens2json
 from textkit.package.texts_to_json import texts2json
 from textkit.package.tokens_to_text import tokens2text
@@ -40,6 +41,7 @@ cli.add_command(showstops)
 cli.add_command(lowercase)
 cli.add_command(uppercase)
 cli.add_command(nonewlines)
+cli.add_command(stem)
 cli.add_command(tokens2json)
 cli.add_command(texts2json)
 cli.add_command(tokens2text)

--- a/textkit/transform/stem.py
+++ b/textkit/transform/stem.py
@@ -2,13 +2,14 @@ import click
 from nltk.stem import PorterStemmer
 from nltk.stem.lancaster import LancasterStemmer
 from nltk.stem.snowball import EnglishStemmer
+from nltk.stem.wordnet import WordNetLemmatizer
 from textkit.utils import read_tokens, output
 
 
 @click.command()
 @click.argument('tokens', type=click.File('r'), default=click.open_file('-'))
 @click.option('--algorithm', default='porter',
-              help='Choice of stemming algorithm: porter, lancaster, snowball',
+              help='Choice of stemming algorithm: porter, lancaster, snowball, wordnet',
               type=click.STRING,
               show_default=True)
 def stem(tokens, algorithm):
@@ -18,7 +19,12 @@ def stem(tokens, algorithm):
     stemmer_classes = {'porter': PorterStemmer,
                        'lancaster': LancasterStemmer,
                        'snowball': EnglishStemmer}
-    if algorithm.lower() in stemmer_classes:
+    if algorithm.lower() == 'wordnet':
+        stemmer = WordNetLemmatizer()
+        for token in content:
+            output(stemmer.lemmatize(token))
+
+    elif algorithm.lower() in stemmer_classes:
         stemmer = stemmer_classes[algorithm.lower()]()
         for token in content:
             output(stemmer.stem(token))

--- a/textkit/transform/stem.py
+++ b/textkit/transform/stem.py
@@ -1,0 +1,29 @@
+import click
+from nltk.stem import PorterStemmer
+from nltk.stem.lancaster import LancasterStemmer
+from nltk.stem.snowball import EnglishStemmer
+from textkit.utils import read_tokens, output
+
+
+@click.command()
+@click.argument('tokens', type=click.File('r'), default=click.open_file('-'))
+@click.option('--algorithm', default='porter',
+              help='Choice of stemming algorithm: porter, lancaster, snowball',
+              type=click.STRING,
+              show_default=True)
+def stem(tokens, algorithm):
+    '''Apply stemming to an iterable of tokens.'''
+    content = read_tokens(tokens)
+
+    stemmer_classes = {'porter': PorterStemmer,
+                       'lancaster': LancasterStemmer,
+                       'snowball': EnglishStemmer}
+    if algorithm.lower() in stemmer_classes:
+        stemmer = stemmer_classes[algorithm.lower()]()
+        for token in content:
+            output(stemmer.stem(token))
+
+    else:
+        # passthrough if algorithm is invalid
+        for token in content:
+            output(token)


### PR DESCRIPTION
@vlandham Addresses #1. The following commands work:

```
textkit text2words test_data/alice.txt | textkit stem --algorithm=porter | less
textkit text2words test_data/alice.txt | textkit stem --algorithm=lancaster | less
textkit text2words test_data/alice.txt | textkit stem --algorithm=SnOwBaLL | less
```

The algorithm string gets lowercased before comparing. Invalid algorithm selection leads to passing through the original token. I feel like a warning should be raised, but I'm not sure how to do that.

I started with the English-language stemmers in NLTK. I left one out because the method to call has a different name. That's simple to handle, so I'll add it in another commit.

I'm happy to apply any style changes that you recommend. Or any changes, really.